### PR TITLE
Issue #8 - Stats caching and refreshing

### DIFF
--- a/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsExtension.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsExtension.java
@@ -2,6 +2,7 @@ package ca.corbett.snotes.extensions.statistics;
 
 import ca.corbett.extensions.AppExtensionInfo;
 import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.gradient.ColorSelectionType;
 import ca.corbett.extras.progress.MultiProgressDialog;
 import ca.corbett.extras.progress.SimpleProgressAdapter;
@@ -17,6 +18,7 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * An optional built-in extension for Snotes that can gather and display
@@ -32,6 +34,7 @@ import java.util.List;
  */
 public class StatisticsExtension extends SnotesExtension {
 
+    private static final Logger log = Logger.getLogger(StatisticsExtension.class.getName());
     private static final String extInfoLocation = "/ca/corbett/snotes/extensions/statistics/extInfo.json";
     private final AppExtensionInfo extInfo;
 
@@ -39,6 +42,11 @@ public class StatisticsExtension extends SnotesExtension {
     private static final String HOT_PROP = "Statistics.Options.hotColor";
     private static final Color DEFAULT_COLD = new Color(48, 48, 212);
     private static final Color DEFAULT_HOT = new Color(212, 48, 96);
+
+    private MessageUtil messageUtil;
+    private static final Object lockObject = new Object();
+    private static volatile boolean loading;
+    private static Statistics statistics;
 
     /**
      * We must supply a no-arg constructor to be invoked by ExtensionManager.
@@ -76,6 +84,38 @@ public class StatisticsExtension extends SnotesExtension {
                           .setSolidColor(DEFAULT_HOT)
                           .setHelpText("Represents the 'hot' end of the data spectrum (higher values)."));
         return props;
+    }
+
+    /**
+     * Returns true if a StatisticsLoaderThread is currently running and loading statistics data, false otherwise.
+     */
+    public static boolean isLoading() {
+        return loading;
+    }
+
+    /**
+     * Invoked when loading of statistics is completed - we will accept the new
+     * object and mark ourselves as no longer loading. If showDialogOnComplete
+     * is true, we will show the StatisticsDialog immediately (assuming the
+     * given Statistics instance is not null).
+     */
+    public static void setStatistics(Statistics stats, boolean showDialogOnComplete) {
+        synchronized(lockObject) {
+            statistics = stats;
+            loading = false;
+        }
+        if (showDialogOnComplete && stats != null) {
+            new StatisticsDialog(stats).setVisible(true);
+        }
+    }
+
+    /**
+     * Returns our currently-loaded statistics data, or null if we haven't loaded any yet.
+     */
+    public static Statistics getStatistics() {
+        synchronized(lockObject) {
+            return statistics;
+        }
     }
 
     /**
@@ -119,13 +159,43 @@ public class StatisticsExtension extends SnotesExtension {
     public List<ActionGroup> getActionGroups() {
         ActionGroup group = new ActionGroup("Statistics", Resources.getIconStats());
         group.addAction(new StatsDialogAction());
+        group.addAction(new StatsRefreshAction());
         return List.of(group);
     }
 
+    private MessageUtil getMessageUtil() {
+        if (messageUtil == null) {
+            messageUtil = new MessageUtil(MainWindow.getInstance(), log);
+        }
+        return messageUtil;
+    }
+
     /**
-     * A very simple action to launch our StatisticsDialog.
+     * This action will disregard any currently cached statistics data and
+     * kick off a loader thread to load fresh statistics data.
      */
-    private static class StatsDialogAction extends EnhancedAction {
+    private class StatsRefreshAction extends EnhancedAction {
+
+        public StatsRefreshAction() {
+            super("Refresh statistics");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            StatisticsLoaderThread loader = new StatisticsLoaderThread(MainWindow.getInstance().getDataManager());
+            loader.addProgressListener(new ProgressListener(loader, false));
+            String message = "Refreshing statistics";
+            MultiProgressDialog dialog = new MultiProgressDialog(MainWindow.getInstance(), message);
+            loading = true;
+            dialog.runWorker(loader, true);
+        }
+    }
+
+    /**
+     * This action will show the StatisticsDialog if statistics have already been loaded.
+     * Otherwise, will kick off a loader thread to load all statistics, and then show the dialog.
+     */
+    private class StatsDialogAction extends EnhancedAction {
 
         public StatsDialogAction() {
             super("Statistics dialog");
@@ -133,12 +203,27 @@ public class StatisticsExtension extends SnotesExtension {
 
         @Override
         public void actionPerformed(ActionEvent e) {
+            // If we already have some, just show them:
+            Statistics stats = getStatistics();
+            if (stats != null) {
+                new StatisticsDialog(stats).setVisible(true);
+                return;
+            }
+
+            // If a load is already in progress, do nothing - the user has clicked the
+            // action link multiple times. They must wait, or cancel the load in progress.
+            if (isLoading()) {
+                log.warning("Ignoring request to show statistics dialog because statistics are currently loading.");
+                return;
+            }
+
+            // Otherwise, let's load them now, and show the dialog when complete:
+            loading = true;
             StatisticsLoaderThread loader = new StatisticsLoaderThread(MainWindow.getInstance().getDataManager());
-            loader.addProgressListener(new ProgressListener(loader));
+            loader.addProgressListener(new ProgressListener(loader, true));
             String message = "Gathering statistics";
             MultiProgressDialog dialog = new MultiProgressDialog(MainWindow.getInstance(), message);
             dialog.runWorker(loader, true);
-
         }
     }
 
@@ -148,22 +233,29 @@ public class StatisticsExtension extends SnotesExtension {
      * a "cancel" button they can use if the loader runs too long. If we detect a cancel event,
      * we simply do nothing here. User can try again later.
      */
-    private static class ProgressListener extends SimpleProgressAdapter {
+    private class ProgressListener extends SimpleProgressAdapter {
 
         private final StatisticsLoaderThread loader;
+        private final boolean showDialogOnComplete;
 
-        public ProgressListener(StatisticsLoaderThread loader) {
+        public ProgressListener(StatisticsLoaderThread loader, boolean showDialogOnComplete) {
             this.loader = loader;
+            this.showDialogOnComplete = showDialogOnComplete;
         }
 
         @Override
         public void progressCanceled() {
-            // User canceled; do nothing.
+            setStatistics(null, false);
+            getMessageUtil().info("Canceled", "Statistics gathering was canceled.");
         }
 
         @Override
         public void progressComplete() {
-            new StatisticsDialog(loader.getStatistics()).setVisible(true);
+            setStatistics(loader.getStatistics(), showDialogOnComplete);
+
+            if (!showDialogOnComplete) {
+                getMessageUtil().info("Completed", "Statistics refresh is complete!");
+            }
         }
     }
 }

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsExtension.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsExtension.java
@@ -14,6 +14,7 @@ import ca.corbett.snotes.extensions.SnotesExtension;
 import ca.corbett.snotes.ui.MainWindow;
 import ca.corbett.snotes.ui.actions.ActionGroup;
 
+import javax.swing.SwingUtilities;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
@@ -45,7 +46,7 @@ public class StatisticsExtension extends SnotesExtension {
 
     private MessageUtil messageUtil;
     private static final Object lockObject = new Object();
-    private static volatile boolean loading;
+    private static boolean loading;
     private static Statistics statistics;
 
     /**
@@ -90,7 +91,9 @@ public class StatisticsExtension extends SnotesExtension {
      * Returns true if a StatisticsLoaderThread is currently running and loading statistics data, false otherwise.
      */
     public static boolean isLoading() {
-        return loading;
+        synchronized(lockObject) {
+            return loading;
+        }
     }
 
     /**
@@ -105,7 +108,7 @@ public class StatisticsExtension extends SnotesExtension {
             loading = false;
         }
         if (showDialogOnComplete && stats != null) {
-            new StatisticsDialog(stats).setVisible(true);
+            SwingUtilities.invokeLater(() -> new StatisticsDialog(stats).setVisible(true));
         }
     }
 
@@ -182,11 +185,22 @@ public class StatisticsExtension extends SnotesExtension {
 
         @Override
         public void actionPerformed(ActionEvent e) {
+            synchronized(lockObject) {
+                // If a load is already in progress, do nothing - the user has clicked the
+                // action link multiple times. They must wait, or cancel the load in progress.
+                if (loading) {
+                    log.warning("Ignoring request to refresh statistics because statistics are currently loading.");
+                    return;
+                }
+
+                // Disregard any currently cached statistics, and kick off a loader thread to load fresh statistics:
+                statistics = null;
+                loading = true;
+            }
             StatisticsLoaderThread loader = new StatisticsLoaderThread(MainWindow.getInstance().getDataManager());
             loader.addProgressListener(new ProgressListener(loader, false));
             String message = "Refreshing statistics";
             MultiProgressDialog dialog = new MultiProgressDialog(MainWindow.getInstance(), message);
-            loading = true;
             dialog.runWorker(loader, true);
         }
     }
@@ -210,15 +224,20 @@ public class StatisticsExtension extends SnotesExtension {
                 return;
             }
 
-            // If a load is already in progress, do nothing - the user has clicked the
-            // action link multiple times. They must wait, or cancel the load in progress.
-            if (isLoading()) {
-                log.warning("Ignoring request to show statistics dialog because statistics are currently loading.");
-                return;
+            synchronized(lockObject) {
+                // If a load is already in progress, do nothing - the user has clicked the
+                // action link multiple times. They must wait, or cancel the load in progress.
+                if (loading) {
+                    log.warning("Ignoring request to show statistics dialog because statistics are currently loading.");
+                    return;
+                }
+
+                // Clear any cached stats (should be none, but let's be sure), and mark ourselves as loading:
+                statistics = null;
+                loading = true;
             }
 
             // Otherwise, let's load them now, and show the dialog when complete:
-            loading = true;
             StatisticsLoaderThread loader = new StatisticsLoaderThread(MainWindow.getInstance().getDataManager());
             loader.addProgressListener(new ProgressListener(loader, true));
             String message = "Gathering statistics";
@@ -228,10 +247,10 @@ public class StatisticsExtension extends SnotesExtension {
     }
 
     /**
-     * Listens to our loader thread, and shows the StatisticsDialog when loading is complete.
+     * Listens to our loader thread, and optionally shows the StatisticsDialog when loading is complete.
      * Our progress dialog will be visible while the loader is running, and the user will have
      * a "cancel" button they can use if the loader runs too long. If we detect a cancel event,
-     * we simply do nothing here. User can try again later.
+     * we null out our cached statistics and show a cancel confirmation message to the user.
      */
     private class ProgressListener extends SimpleProgressAdapter {
 
@@ -246,7 +265,8 @@ public class StatisticsExtension extends SnotesExtension {
         @Override
         public void progressCanceled() {
             setStatistics(null, false);
-            getMessageUtil().info("Canceled", "Statistics gathering was canceled.");
+            SwingUtilities.invokeLater(() -> getMessageUtil().info("Canceled",
+                                                                   "Statistics gathering was canceled."));
         }
 
         @Override
@@ -254,7 +274,8 @@ public class StatisticsExtension extends SnotesExtension {
             setStatistics(loader.getStatistics(), showDialogOnComplete);
 
             if (!showDialogOnComplete) {
-                getMessageUtil().info("Completed", "Statistics refresh is complete!");
+                SwingUtilities.invokeLater(() -> getMessageUtil().info("Completed",
+                                                                       "Statistics refresh is complete!"));
             }
         }
     }


### PR DESCRIPTION
This PR addresses issue #8 by adding a caching mechanism to statistics loading. This allows statistics to be gathered once and then re-used across multiple visits to the `StatisticsDialog`, instead of reloading them from scratch each time.

Added a manual "refresh statistics" action to discard the currently-cached statistics and reload from scratch, if desired.

Closes #8 
