### PR TITLE
Issue #18 - adding word-based statistics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,14 +28,17 @@ The extension follows the Snotes plugin pattern: `StatisticsExtension` extends `
 1. User triggers the Statistics action → `StatisticsLoaderThread` starts
 2. Loader runs **6 parallel worker tasks** via `ExecutorService`: general counts, per-year, all-months, per-year+month, day-of-week, and phrase extraction
 3. Results collected into the `Statistics` model
-4. `StatisticsDialog` renders 5 tabs: Overview, Years, Months, Weeks, Phrases — each backed by custom heatmap chart components in the `charts/` subpackage
+4. `StatisticsDialog` renders 6 tabs: Overview, Years, Months, Weeks, Phrases, Words — each backed by custom heatmap chart components in the `charts/` subpackage
 
 **Key classes:**
-- `StatisticsUtil` — static analysis algorithms (word counting, phrase extraction, value normalization)
+- `StatisticsUtil` — static analysis algorithms (word counting, phrase extraction, top-word ranking, value normalization)
 - `StatisticsLoaderThread` — background worker; extends `SimpleProgressWorker` from the Snotes framework
 - `Statistics` — data bag with final fields passed from loader to dialog
 - `PhraseList` — wraps `List<Phrase>` with a `filter(n, minPhraseLength)` method that sorts by frequency (tiebreaker: longer phrase wins)
 - `Phrase` — Java `record`; immutable value object
+- `WordList` — wraps `List<Word>` and also tracks the total count of unique words scanned across all notes (`getUniqueWordCount()`)
+- `Word` — Java `record`; immutable value object holding a word and its occurrence count
+- `WordSearchThread` — on-demand background worker (extends `SimpleProgressWorker`) that calls `StatisticsUtil.findWords()` for a user-supplied set of specific words
 
 **Chart components** (`charts/` package):
 - `ValueCell` — single 24×24px heatmap cell; blends between configurable cold/hot colors
@@ -47,6 +50,19 @@ The extension follows the Snotes plugin pattern: `StatisticsExtension` extends `
 - Phrases are 2–10 words (`MIN_PHRASE_LENGTH`, `MAX_PHRASE_LENGTH`)
 - Phrases appearing only once are discarded (`MIN_PHRASE_FREQUENCY = 2`)
 - Text is normalized to lowercase with punctuation stripped, **except** apostrophes are preserved
+
+**Word analysis constants** (in `StatisticsUtil`):
+- Words shorter than 5 characters are skipped during general top-word collection (`MIN_WORD_LENGTH = 5`), to exclude noise like "a", "the", "but"
+- `MIN_WORD_LENGTH` is **ignored** when searching for specific words (via the word search feature)
+- The top-word list is capped at 25 entries (`TOP_N_WORDS = 25`)
+- Single-occurrence words are pruned before materializing to a list (re-uses `MIN_PHRASE_FREQUENCY`)
+- `StatisticsUtil.findWords(List<Note>, int)` returns a `WordList` for the general top-N use case
+- `StatisticsUtil.findWords(List<Note>, Set<String>, int)` accepts a set of specific words to look up; `WordList.getUniqueWordCount()` is populated by both overloads
+
+**Words tab (in `StatisticsDialog`):**
+- Displays the top 25 words and the total number of unique words scanned across all notes
+- Provides an interactive word search: the user enters a comma-separated list of words, `WordSearchThread` runs off the Swing EDT, and results are shown in a dialog
+- Word search input is parsed via `TagList.fromRawString()` for convenient comma-separated, de-duplicated, normalised tokenisation
 
 **Performance-sensitive paths** in `StatisticsUtil.findPhrases()`:
 - Uses a single-pass char-by-char loop (not regex) for normalization

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/Phrase.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/Phrase.java
@@ -3,8 +3,8 @@ package ca.corbett.snotes.extensions.statistics;
 /**
  * A simple record to represent a phrase and its occurrence count.
  *
- * @param phrase Any text phrase of two or more words. It can be empty, but it cannot be null.
- * @param wordCount The count of words in this phrase. A non-negative integer (zero if the phrase is empty).
+ * @param phrase Any text phrase of two or more words. Must not be null, and should not be blank or empty (not checked).
+ * @param wordCount The count of words in this phrase. Must be greater than zero.
  * @param occurrenceCount The number of times this phrase occurs in the analyzed notes. Must be greater than zero.
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since Snotes 2.0

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/Phrase.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/Phrase.java
@@ -5,7 +5,7 @@ package ca.corbett.snotes.extensions.statistics;
  *
  * @param phrase Any text phrase of two or more words. It can be empty, but it cannot be null.
  * @param wordCount The count of words in this phrase. A non-negative integer (zero if the phrase is empty).
- * @param occurrenceCount The number of times this phrase occurs in the analyzed notes. A non-negative integer.
+ * @param occurrenceCount The number of times this phrase occurs in the analyzed notes. Must be greater than zero.
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since Snotes 2.0
  */
@@ -15,8 +15,11 @@ public record Phrase(String phrase, int wordCount, int occurrenceCount) {
         if (phrase == null) {
             throw new NullPointerException("phrase cannot be null");
         }
-        if (occurrenceCount < 0) {
-            throw new IllegalArgumentException("occurrenceCount cannot be negative");
+        if (wordCount <= 0) {
+            throw new IllegalArgumentException("wordCount cannot be negative or zero");
+        }
+        if (occurrenceCount <= 0) {
+            throw new IllegalArgumentException("occurrenceCount cannot be negative or zero");
         }
     }
 }

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/PhraseList.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/PhraseList.java
@@ -16,7 +16,6 @@ public class PhraseList {
 
     /**
      * Constructs a PhraseList with the given list of phrases.
-     * @param phrases
      */
     public PhraseList(List<Phrase> phrases) {
         this.phrases = phrases == null ? List.of() : phrases; // default to empty list if null

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/Statistics.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/Statistics.java
@@ -31,6 +31,7 @@ public class Statistics {
     private final Map<Integer, Integer> noteCountByDayOfWeek; // day of week (1-7) -> total notes on that day (all years)
     private final PhraseList allPhrases; // all phrases of length 2-10 across all notes, sorted by frequency
     private final Map<Integer, List<Phrase>> phrasesByLength; // phrase length -> list of phrases of that length
+    private final WordList topWords; // The top N words across all notes, sorted by frequency.
 
     public Statistics(List<Note> allNotes, int totalNoteCount, int totalWordCount, List<Integer> uniqueYears,
                       Map<Integer, Integer> wordCountByYear, Map<Integer, Integer> noteCountByYear,
@@ -38,7 +39,7 @@ public class Statistics {
                       Map<Integer, Map<Integer, Integer>> wordCountByYearAndMonth,
                       Map<Integer, Map<Integer, Integer>> noteCountByYearAndMonth,
                       Map<Integer, Integer> wordCountByDayOfWeek, Map<Integer, Integer> noteCountByDayOfWeek,
-                      PhraseList allPhrases, Map<Integer, List<Phrase>> phrasesByLength) {
+                      PhraseList allPhrases, Map<Integer, List<Phrase>> phrasesByLength, WordList topWords) {
         this.allNotes = allNotes;
         this.totalNoteCount = totalNoteCount;
         this.totalWordCount = totalWordCount;
@@ -53,6 +54,7 @@ public class Statistics {
         this.noteCountByDayOfWeek = noteCountByDayOfWeek;
         this.allPhrases = allPhrases;
         this.phrasesByLength = phrasesByLength;
+        this.topWords = topWords;
     }
 
     public List<Note> getAllNotes() {
@@ -177,5 +179,9 @@ public class Statistics {
 
     public Map<Integer, List<Phrase>> getPhrasesByLength() {
         return phrasesByLength;
+    }
+
+    public WordList getTopWords() {
+        return topWords;
     }
 }

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsDialog.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsDialog.java
@@ -376,7 +376,7 @@ public class StatisticsDialog extends JDialog {
         wordSearchForm.add(LabelField.createBoldHeaderLabel("Word search", 14));
         wordSearchField = new ShortTextField("Search for word(s):", 20);
         wordSearchField.setAllowBlank(false);
-        wordSearchField.setHelpText("Enter a comma-separated list of words to search for, or a single word.");
+        wordSearchField.setHelpText("Enter a comma-separated list of 1-25 words to search for.");
         wordSearchForm.add(wordSearchField);
 
         wordSearchForm.add(new ButtonField(List.of(new WordSearchAction())));

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsDialog.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsDialog.java
@@ -1,16 +1,24 @@
 package ca.corbett.snotes.extensions.statistics;
 
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.ScrollUtil;
+import ca.corbett.extras.progress.MultiProgressDialog;
+import ca.corbett.extras.progress.SimpleProgressAdapter;
 import ca.corbett.forms.Alignment;
 import ca.corbett.forms.FormPanel;
+import ca.corbett.forms.fields.ButtonField;
 import ca.corbett.forms.fields.ComboField;
 import ca.corbett.forms.fields.LabelField;
 import ca.corbett.forms.fields.PanelField;
+import ca.corbett.forms.fields.ShortTextField;
 import ca.corbett.snotes.Resources;
 import ca.corbett.snotes.extensions.statistics.charts.AllYearsChart;
 import ca.corbett.snotes.extensions.statistics.charts.MonthChart;
 import ca.corbett.snotes.extensions.statistics.charts.WeekChart;
 import ca.corbett.snotes.extensions.statistics.charts.YearChart;
+import ca.corbett.snotes.model.Tag;
+import ca.corbett.snotes.model.TagList;
 import ca.corbett.snotes.ui.MainWindow;
 
 import javax.swing.BorderFactory;
@@ -20,6 +28,7 @@ import javax.swing.JLabel;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -27,12 +36,16 @@ import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.event.ActionEvent;
 import java.time.DayOfWeek;
 import java.time.Month;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * Provides a JTabbedPane-based dialog for showing various statistics about the user's notes.
@@ -42,6 +55,8 @@ import java.util.Locale;
  */
 public class StatisticsDialog extends JDialog {
 
+    private final Logger log = Logger.getLogger(StatisticsDialog.class.getName());
+
     private static final int DIALOG_WIDTH = 600;
     private final Statistics stats;
     private ComboField<String> monthCombo;
@@ -49,6 +64,9 @@ public class StatisticsDialog extends JDialog {
     private MonthChart monthChart;
     private ComboField<Integer> phraseLengthCombo;
     private final LabelField[] phraseLabels = new LabelField[10];
+    private FormPanel wordSearchForm;
+    private ShortTextField wordSearchField;
+    private MessageUtil messageUtil;
 
     /**
      * Creates a StatisticsDialog using the given Statistics instance as the source of all
@@ -72,6 +90,7 @@ public class StatisticsDialog extends JDialog {
         tabPane.addTab("Months", ScrollUtil.buildScrollPane(buildMonthsTab()));
         tabPane.addTab("Weeks", ScrollUtil.buildScrollPane(buildWeeksTab()));
         tabPane.addTab("Phrases", ScrollUtil.buildScrollPane(buildPhrasesTab()));
+        tabPane.addTab("Words", ScrollUtil.buildScrollPane(buildWordsTab()));
 
         setLayout(new BorderLayout());
         add(tabPane, BorderLayout.CENTER);
@@ -312,8 +331,127 @@ public class StatisticsDialog extends JDialog {
         // Otherwise, load them up (they are already in descending order):
         for (int i = 0; i < filtered.size() && i < phraseLabels.length; i++) {
             Phrase phrase = filtered.get(i);
-            String label = String.format("<html><b>%s</b> (used %,d times)</html>", phrase.phrase(), phrase.occurrenceCount());
+            String label = String.format("<html>%d. <b>%s</b> (used %,d times)</html>", (i + 1), phrase.phrase(),
+                                         phrase.occurrenceCount());
             phraseLabels[i].setText(label);
+        }
+    }
+
+    /**
+     * Builds out our "Top N Words" tab, showing the most common words across all notes and their occurrence counts.
+     * Also provides a control to allow an on-the-fly search for specific word(s).
+     */
+    private JComponent buildWordsTab() {
+        wordSearchForm = new FormPanel(Alignment.TOP_LEFT);
+        wordSearchForm.setBorderMargin(8);
+        wordSearchForm.add(LabelField.createBoldHeaderLabel("Most common words"));
+
+        WordList topWords = stats.getTopWords();
+
+        // If the "total unique words" feature is enabled, show that count here.
+        if (topWords.getUniqueWordCount() != WordList.NO_DATA) {
+            wordSearchForm.add(
+                    new LabelField(String.format("You've typed a total of %,d unique words across all your notes.",
+                                                 topWords.getUniqueWordCount())));
+        }
+
+        if (topWords.getWords().isEmpty()) {
+            wordSearchForm.add(new LabelField("(no data)"));
+            return wordSearchForm; // Don't show the rest if there's nothing to work with.
+        }
+
+        // Show a label for each one. The list should already be sorted in descending order.
+        // We don't know exactly how many entries there will be here, but it should be reasonable
+        // enough to just show inline like this:
+        int number = 1;
+        for (Word word : topWords.getWords()) {
+            String label = String.format("<html>%d. <b>%s</b> (used %,d times)</html>", number, word.word(),
+                                         word.occurrenceCount());
+            LabelField labelField = new LabelField(label);
+            labelField.getMargins().setLeft(20); // indent the list a bit
+            wordSearchForm.add(labelField);
+            number++;
+        }
+
+        wordSearchForm.add(LabelField.createBoldHeaderLabel("Word search", 14));
+        wordSearchField = new ShortTextField("Search for word(s):", 20);
+        wordSearchField.setAllowBlank(false);
+        wordSearchField.setHelpText("Enter a comma-separated list of words to search for, or a single word.");
+        wordSearchForm.add(wordSearchField);
+
+        wordSearchForm.add(new ButtonField(List.of(new WordSearchAction())));
+
+        return wordSearchForm;
+    }
+
+    /**
+     * Shows the result of a word search in an info dialog.
+     */
+    private void showWordSearchResults(WordList foundWords) {
+        if (foundWords == null) {
+            getMessageUtil().error("Word search error", "An unexpected error occurred while searching for words.");
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder("Search results:\n\n");
+        int totalOccurrences = foundWords.getWords().stream().mapToInt(Word::occurrenceCount).sum();
+        sb.append(String.format("Found %,d combined occurrences across all notes.\n\n", totalOccurrences));
+        int num = 1;
+        for (Word word : foundWords.getWords()) {
+            // This list might be smaller than we expect! Not all words may have been found.
+            // Any word not mentioned here has zero occurrences, and we can just ignore it in the results.
+            // If no word was found, the label above will show "0 combined occurrences", which is fine.
+            sb.append(String.format("  %d. %s: %,d occurrences\n", num, word.word(), word.occurrenceCount()));
+            num++;
+        }
+        getMessageUtil().info("Word search results", sb.toString());
+    }
+
+    private MessageUtil getMessageUtil() {
+        if (messageUtil == null) {
+            messageUtil = new MessageUtil(this, log);
+        }
+        return messageUtil;
+    }
+
+    /**
+     * Invoked when the user clicks the "Search" button on the Words tab. This will kick off a WordSearchThread
+     * to do the actual searching, and will show a progress dialog while the search is underway.
+     * A dialog with the results is shown upon completion.
+     */
+    private class WordSearchAction extends EnhancedAction {
+
+        private WordSearchAction() {
+            super("Search");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (!wordSearchForm.isFormValid()) {
+                return; // field was left blank - user must fill it in first
+            }
+
+            // This is of course not a TagList, but TagList conveniently already
+            // has parsing logic for turning a comma-separated string into a list of normalized,
+            // de-duplicated, non-blank items, so let's use it:
+            TagList tagList = TagList.fromRawString(wordSearchField.getText());
+
+            // Convert to a set for findWords():
+            Set<String> wordSet = new HashSet<>(tagList.getTags().size());
+            for (Tag tag : tagList.getTags()) {
+                wordSet.add(tag.getTag());
+            }
+
+            // Fire off a worker thread to do the loading off the Swing EDT:
+            WordSearchThread worker = new WordSearchThread(stats.getAllNotes(), wordSet);
+            worker.addProgressListener(new SimpleProgressAdapter() {
+                @Override
+                public void progressComplete() {
+                    SwingUtilities.invokeLater(() -> showWordSearchResults(worker.getResults()));
+                }
+            });
+            MultiProgressDialog dialog = new MultiProgressDialog(StatisticsDialog.this, "Searching for words...");
+            dialog.runWorker(worker, true);
         }
     }
 }

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsLoaderThread.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsLoaderThread.java
@@ -55,6 +55,7 @@ public class StatisticsLoaderThread extends SimpleProgressWorker {
     private Map<Integer, Integer> noteCountByDayOfWeek; // day of week (1-7) -> total notes on that day (all years)
     private PhraseList allPhrases; // all phrases of length 2-10 across all notes, sorted by frequency
     private Map<Integer, List<Phrase>> phrasesByLength; // phrase length -> list of phrases of that length
+    private WordList topWords; // the top N words across all notes, sorted by frequency
 
     public StatisticsLoaderThread(DataManager dataManager) {
         this.dataManager = dataManager;
@@ -83,7 +84,8 @@ public class StatisticsLoaderThread extends SimpleProgressWorker {
                               wordCountByDayOfWeek,
                               noteCountByDayOfWeek,
                               allPhrases,
-                              phrasesByLength);
+                              phrasesByLength,
+                              topWords);
     }
 
     @Override
@@ -96,6 +98,7 @@ public class StatisticsLoaderThread extends SimpleProgressWorker {
         workers.add(this::loadMonthData);
         workers.add(this::loadWeekData);
         workers.add(this::loadPhrases);
+        workers.add(this::loadWords);
 
         // we do one pass to find all phrases, then one pass per phrase length to filter them:
         int phraseSteps = (StatisticsUtil.MAX_PHRASE_LENGTH - StatisticsUtil.MIN_PHRASE_LENGTH);
@@ -251,5 +254,19 @@ public class StatisticsLoaderThread extends SimpleProgressWorker {
             phrasesByLength.put(length, allPhrases.filter(10, length));
             chunkComplete();
         }
+    }
+
+    /**
+     * Finds the top N words of at least MIN_WORD_LENGTH across all notes, and counts their frequencies.
+     */
+    void loadWords() {
+        Stopwatch.start("loadWords");
+        List<Note> allNotes = dataManager.getNotes();
+        topWords = StatisticsUtil.findWords(allNotes, StatisticsUtil.TOP_N_WORDS);
+        chunkComplete();
+        Stopwatch.stop("loadWords");
+        log.info("StatisticsLoaderThread: loadWords: took "
+                         + Stopwatch.reportFormatted("loadWords")
+                         + " to load top words");
     }
 }

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsUtil.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsUtil.java
@@ -124,12 +124,12 @@ public class StatisticsUtil {
     /**
      * Returns a WordList containing the top N most common words across the given list of notes,
      * only considering the given specific words, and ignoring all others. You can pass null
-     * or an empty list for specificWords to consider all words, in which case, this is
+     * or an empty set for specificWords to consider all words, in which case, this is
      * equivalent to findWords(List&lt;Note&gt;, int).
      * <p>
      * Note: MIN_WORD_LENGTH is ignored if you pass in specificWords to search for!
      * The unique word count feature will still work, though.
-     * </P>
+     * </p>
      */
     public static WordList findWords(List<Note> notes, Set<String> specificWords, int N) {
         if (notes == null || notes.isEmpty() || N <= 0) {

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsUtil.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/StatisticsUtil.java
@@ -5,8 +5,10 @@ import ca.corbett.snotes.model.Query;
 
 import java.time.DayOfWeek;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Handy utility methods for gathering statistics from lists of notes.
@@ -19,6 +21,8 @@ public class StatisticsUtil {
     public static final int MIN_PHRASE_LENGTH = 2; // a phrase must be at least 2 words long to be interesting
     public static final int MAX_PHRASE_LENGTH = 10; // very rare we'd get more than 10 words in a common phrase
     public static final int MIN_PHRASE_FREQUENCY = 2; // single-occurrence phrases are not interesting and are very expensive to store
+    public static final int MIN_WORD_LENGTH = 5; // short words are very common and not interesting: a, an, the, that...
+    public static final int TOP_N_WORDS = 25; // Completely arbitrary choice: top 25 words.
 
     /**
      * ISO-8601 defines Monday as the first day of the week (1) and Sunday as the last day of the week (7).
@@ -110,6 +114,94 @@ public class StatisticsUtil {
     }
 
     /**
+     * Returns a WordList containing the top N most common words across the given list of notes,
+     * along with their occurrence counts.
+     */
+    public static WordList findWords(List<Note> notes, int N) {
+        return findWords(notes, null, N);
+    }
+
+    /**
+     * Returns a WordList containing the top N most common words across the given list of notes,
+     * only considering the given specific words, and ignoring all others. You can pass null
+     * or an empty list for specificWords to consider all words, in which case, this is
+     * equivalent to findWords(List&lt;Note&gt;, int).
+     * <p>
+     * Note: MIN_WORD_LENGTH is ignored if you pass in specificWords to search for!
+     * The unique word count feature will still work, though.
+     * </P>
+     */
+    public static WordList findWords(List<Note> notes, Set<String> specificWords, int N) {
+        if (notes == null || notes.isEmpty() || N <= 0) {
+            return new WordList(null); // default to empty list if null or invalid N
+        }
+        if (specificWords == null) {
+            specificWords = Set.of(); // default to empty set if null
+        }
+
+        Map<String, Integer> wordCounts = new HashMap<>();
+        Set<String> uniqueWords = new HashSet<>(); // tracks total unique words scanned, for the uniqueWordCount feature
+        for (Note note : notes) {
+
+            // Cache getText() to avoid repeated virtual calls:
+            String noteText = note == null ? null : note.getText();
+
+            // Skip null notes, and notes with no text:
+            if (noteText == null || noteText.isBlank()) {
+                continue;
+            }
+
+            // Normalize the text and ensure we have something left to work with after normalization:
+            String text = normalizeText(noteText);
+            if (text.isBlank()) {
+                continue;
+            }
+
+            // Now we can split on whitespace:
+            String[] words = text.split("\\s+");
+            for (String word : words) {
+                uniqueWords.add(word); // track this word, even if it's a short one.
+
+                // Are we only considering specific words?
+                if (!specificWords.isEmpty()) {
+                    if (specificWords.contains(word)) {
+                        wordCounts.put(word, wordCounts.getOrDefault(word, 0) + 1);
+                    }
+                    continue; // skip the rest of this loop
+                }
+
+                // We are considering all words. But, we should
+                // skip short words when counting occurrences, since they are very
+                // common and not interesting: a, an, the, but, etc.
+                if (word.length() < MIN_WORD_LENGTH) {
+                    continue;
+                }
+                wordCounts.put(word, wordCounts.getOrDefault(word, 0) + 1);
+            }
+        }
+
+        // Prune all single-occurrence words before materializing into a list.
+        // In large datasets, they are the overwhelming majority of map entries,
+        // which may cause an OutOfMemoryException during .toList().
+        // Note: we re-use MIN_PHRASE_FREQUENCY here. It serves the same purpose.
+        // Also note: we don't do this prune if we were given specific words to search for.
+        // That's because our list will be MUCH smaller, and we want to count even single occurrences:
+        if (specificWords.isEmpty()) {
+            wordCounts.values().removeIf(count -> count < MIN_PHRASE_FREQUENCY);
+        }
+
+        // Convert to WordList and return, sorted by count descending:
+        return new WordList(wordCounts.entrySet()
+                                      .stream()
+                                      .map(entry -> new Word(entry.getKey(), entry.getValue()))
+                                      .sorted((w1, w2) -> Integer.compare(w2.occurrenceCount(),
+                                                                          w1.occurrenceCount())) // sort by count, descending
+                                      .limit(N)
+                                      .toList(),
+                            uniqueWords.size()); // total unique words scanned, for the uniqueWordCount feature
+    }
+
+    /**
      * Given a list of notes, finds all phrases of length 2 to MAX_PHRASE_LENGTH that appear
      * in the text of those notes, and counts how many times each phrase appears.
      * <p>
@@ -155,22 +247,8 @@ public class StatisticsUtil {
                 continue;
             }
 
-            // Single-pass normalization: lowercase + replace non-word chars with spaces.
-            // This replaces the two-pass approach (toLowerCase then replaceAll) with one
-            // character-level loop, avoiding a second full scan and regex overhead.
-            StringBuilder normalized = new StringBuilder(noteText.length());
-            for (int ci = 0; ci < noteText.length(); ci++) {
-                char c = noteText.charAt(ci);
-                if (Character.isLetterOrDigit(c) || c == '\'') {
-                    normalized.append(Character.toLowerCase(c));
-                }
-                else {
-                    normalized.append(' ');
-                }
-            }
-            String text = normalized.toString().trim();
-
-            // If the normalization left us with nothing, then we have no phrases to count:
+            // Normalize the text and ensure we have something left to work with after normalization:
+            String text = normalizeText(noteText);
             if (text.isBlank()) {
                 continue;
             }
@@ -210,6 +288,34 @@ public class StatisticsUtil {
                                                                entry.getValue()[0],
                                                                entry.getValue()[1]))
                                       .toList());
+    }
+
+    /**
+     * Performs a single-pass normalization of the given text, converting it to lowercase and
+     * replacing all non-word characters (except apostrophes) with spaces. This replaces the
+     * old two-pass approach of using toLowerCase() followed by replaceAll(), which required
+     * two full scans of the text and incurred regex overhead.
+     *
+     * @param text Any text string.
+     * @return A normalized version of the given text. Might be empty if normalization stripped everything.
+     */
+    public static String normalizeText(String text) {
+        if (text == null || text.isEmpty()) {
+            return ""; // easy check
+        }
+
+        int len = text.length();
+        StringBuilder normalized = new StringBuilder(len);
+        for (int ci = 0; ci < len; ci++) {
+            char c = text.charAt(ci);
+            if (Character.isLetterOrDigit(c) || c == '\'') {
+                normalized.append(Character.toLowerCase(c));
+            }
+            else {
+                normalized.append(' ');
+            }
+        }
+        return normalized.toString().trim();
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/Word.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/Word.java
@@ -1,0 +1,24 @@
+package ca.corbett.snotes.extensions.statistics;
+
+/**
+ * A simple record to represent a word and its occurrence count.
+ * During our stats load, all text is normalized to lowercase, and stripped
+ * of all punctuation, except apostrophes. So, words like "isn't" are preserved as "isn't",
+ * but "hello!" and "hello" would both be normalized to "hello".
+ *
+ * @param word            The word in question. Must not be null.
+ * @param occurrenceCount The number of times this word occurs in the (normalized) analyzed notes. Must be &gt; 0.
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 2.0
+ */
+public record Word(String word, int occurrenceCount) {
+
+    public Word {
+        if (word == null) {
+            throw new NullPointerException("word cannot be null");
+        }
+        if (occurrenceCount <= 0) {
+            throw new IllegalArgumentException("occurrenceCount cannot be negative or zero");
+        }
+    }
+}

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/WordList.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/WordList.java
@@ -47,8 +47,8 @@ public class WordList {
 
     /**
      * Returns the total number of unique words that were scanned in all notes.
-     * This might be NO_DATA if the feature is disabled.
-     * This might legitimately be zero, if the given list of notes was empty.
+     * This is {@link #NO_DATA} if the feature was not populated, including when the
+     * current statistics workflow is given null or empty notes.
      */
     public int getUniqueWordCount() {
         return uniqueWordCount;

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/WordList.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/WordList.java
@@ -1,0 +1,56 @@
+package ca.corbett.snotes.extensions.statistics;
+
+import java.util.List;
+
+/**
+ * Represents a list of words and their occurrence counts, as gathered from the analyzed notes.
+ * This class also tracks the total number of unique words that were scanned in all notes.
+ * That is, not just the top N, but the TOTAL number of unique words that were scanned.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 2.0
+ */
+public class WordList {
+
+    public static final int NO_DATA = -1;
+
+    private final int uniqueWordCount;
+    private final List<Word> words;
+
+    /**
+     * Constructs a WordList with the given list of words.
+     * The list is expected to be sorted in descending order by occurrence count.
+     * A null list is considered equivalent to an empty list.
+     * The "total unique word count" feature is disabled with this constructor.
+     * Use WordList(List&lt;Word&gt;, int) if you want to specify the total unique word count as well.
+     */
+    public WordList(List<Word> words) {
+        this(words, NO_DATA);
+    }
+
+    /**
+     * Constructs a WordList with the given list of words,
+     * and also enables the "total unique word count" feature by accepting a count
+     * of the total number of unique words that were scanned in all notes.
+     */
+    public WordList(List<Word> words, int uniqueWordCount) {
+        this.words = words == null ? List.of() : words; // default to empty list if null
+        this.uniqueWordCount = uniqueWordCount;
+    }
+
+    /**
+     * Returns a copy of our word list.
+     */
+    public List<Word> getWords() {
+        return List.copyOf(words); // return a copy to preserve immutability
+    }
+
+    /**
+     * Returns the total number of unique words that were scanned in all notes.
+     * This might be NO_DATA if the feature is disabled.
+     * This might legitimately be zero, if the given list of notes was empty.
+     */
+    public int getUniqueWordCount() {
+        return uniqueWordCount;
+    }
+}

--- a/src/main/java/ca/corbett/snotes/extensions/statistics/WordSearchThread.java
+++ b/src/main/java/ca/corbett/snotes/extensions/statistics/WordSearchThread.java
@@ -1,0 +1,53 @@
+package ca.corbett.snotes.extensions.statistics;
+
+import ca.corbett.extras.progress.SimpleProgressWorker;
+import ca.corbett.snotes.model.Note;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A very simple thread to wrap a call to findWords() in StatisticsUtil with a given
+ * list of specific search words. Cancellation events are ignored by this thread!
+ * There's literally only one step, so by the time we receive a cancel message
+ * from our dialog, our work would already be complete. It's therefore safe
+ * to invoke getResults() even if the user hit cancel.
+ * <p>
+ * Note that the callback fires on this worker thread! Take care when updating the UI.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 2.0
+ */
+public class WordSearchThread extends SimpleProgressWorker {
+
+    private final List<Note> notesToSearch;
+    private final Set<String> searchWords;
+    private WordList results;
+
+    public WordSearchThread(List<Note> allNotes, Set<String> searchWords) {
+        this.notesToSearch = allNotes;
+        this.searchWords = searchWords;
+    }
+
+    /**
+     * Will return our search results, or null if the search has not yet been performed
+     * or has not yet completed.
+     */
+    public WordList getResults() {
+        return results;
+    }
+
+    @Override
+    public void run() {
+        this.results = null;
+        fireProgressBegins(2);
+        fireProgressUpdate(1, "Searching for words...");
+        try {
+            this.results = StatisticsUtil.findWords(notesToSearch, searchWords, StatisticsUtil.TOP_N_WORDS);
+        }
+        finally {
+            fireProgressComplete(); // even if canceled, doesn't matter, just fire complete.
+        }
+    }
+}

--- a/src/test/java/ca/corbett/snotes/extensions/statistics/StatisticsUtilTest.java
+++ b/src/test/java/ca/corbett/snotes/extensions/statistics/StatisticsUtilTest.java
@@ -371,7 +371,7 @@ class StatisticsUtilTest {
 
     @Test
     public void findWords_shouldIgnoreShortWords() {
-        // GIVEN notes where all recurring words are shorter than MIN_WORD_LENGTH (4 chars):
+        // GIVEN notes where all recurring words are shorter than MIN_WORD_LENGTH:
         Note note1 = new Note();
         note1.setText("the cat sat on the mat");
         Note note2 = new Note();

--- a/src/test/java/ca/corbett/snotes/extensions/statistics/StatisticsUtilTest.java
+++ b/src/test/java/ca/corbett/snotes/extensions/statistics/StatisticsUtilTest.java
@@ -8,6 +8,7 @@ import ca.corbett.snotes.model.filter.YearFilter;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -270,5 +271,498 @@ class StatisticsUtilTest {
 
         // THEN no phrases should be returned because all note text is whitespace:
         assertTrue(result.getPhrases().isEmpty());
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // findWords tests
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void findWords_withNullNotes_shouldReturnEmptyWordList() {
+        // GIVEN a null note list:
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(null, 10);
+
+        // THEN we should get an empty word list:
+        assertTrue(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_withEmptyNotes_shouldReturnEmptyWordList() {
+        // GIVEN an empty note list:
+        List<Note> notes = List.of();
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(notes, 10);
+
+        // THEN we should get an empty word list:
+        assertTrue(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_withZeroN_shouldReturnEmptyWordList() {
+        // GIVEN a note with repeating content:
+        Note note = new Note();
+        note.setText("hello world hello world");
+
+        // WHEN we call findWords with N = 0:
+        WordList result = StatisticsUtil.findWords(List.of(note), 0);
+
+        // THEN the result should be empty because N=0 means "return nothing":
+        assertTrue(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_withNegativeN_shouldReturnEmptyWordList() {
+        // GIVEN a note with repeating content:
+        Note note = new Note();
+        note.setText("hello world hello world");
+
+        // WHEN we call findWords with a negative N:
+        WordList result = StatisticsUtil.findWords(List.of(note), -1);
+
+        // THEN the result should be empty because N <= 0 is invalid:
+        assertTrue(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_withNullNoteText_shouldBeIgnored() {
+        // GIVEN a note with null text alongside a note with valid repeating text:
+        Note nullTextNote = new Note();
+        nullTextNote.setText(null);
+        Note realNote = new Note();
+        realNote.setText("hello world hello world");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(nullTextNote, realNote), 10);
+
+        // THEN the null-text note should be silently ignored,
+        // and words from the real note should still be found:
+        assertFalse(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_withOnlyPunctuation_shouldReturnEmptyWordList() {
+        // GIVEN a note that contains only punctuation:
+        Note note = new Note();
+        note.setText("!@#$%^&*()");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note), 10);
+
+        // THEN it should return an empty word list, because there are no actual words:
+        assertTrue(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_withWhitespaceOnlyNotes_shouldReturnEmptyWordList() {
+        // GIVEN notes with non-empty but whitespace-only text:
+        Note note1 = new Note();
+        note1.setText("   ");
+        Note note2 = new Note();
+        note2.setText("\t\n");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN no words should be returned because all note text is whitespace:
+        assertTrue(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_shouldIgnoreShortWords() {
+        // GIVEN notes where all recurring words are shorter than MIN_WORD_LENGTH (4 chars):
+        Note note1 = new Note();
+        note1.setText("the cat sat on the mat");
+        Note note2 = new Note();
+        note2.setText("the cat sat on the mat");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN short words like "the", "cat", "sat", "on" should be ignored
+        // because they are shorter than MIN_WORD_LENGTH:
+        assertTrue(result.getWords().stream().noneMatch(w -> w.word().length() < StatisticsUtil.MIN_WORD_LENGTH),
+                   "No words shorter than MIN_WORD_LENGTH should be returned");
+    }
+
+    @Test
+    public void findWords_shouldPruneSingleOccurrenceWords() {
+        // GIVEN notes where every long-enough word appears exactly once:
+        Note note1 = new Note();
+        note1.setText("alpha bravo charlie delta");
+        Note note2 = new Note();
+        note2.setText("echo foxtrot golf hotel");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN the result should be empty because all words occur only once:
+        assertTrue(result.getWords().isEmpty());
+    }
+
+    @Test
+    public void findWords_shouldStripPunctuationAndNormalizeToLowercase() {
+        // GIVEN four notes each containing "hello" and "world" with different cases and punctuation:
+        Note note1 = new Note();
+        note1.setText("Hello, World!");
+        Note note2 = new Note();
+        note2.setText("hello world!");
+        Note note3 = new Note();
+        note3.setText("HELLO WORLD.");
+        Note note4 = new Note();
+        note4.setText("hello, world");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2, note3, note4), 10);
+
+        // THEN punctuation should be stripped and text normalized to lowercase,
+        // so all four occurrences of each word count towards the same normalized form:
+        List<Word> words = result.getWords();
+        assertTrue(words.stream().anyMatch(w -> w.word().equals("hello") && w.occurrenceCount() == 4),
+                   "Expected \"hello\" with occurrence count 4");
+        assertTrue(words.stream().anyMatch(w -> w.word().equals("world") && w.occurrenceCount() == 4),
+                   "Expected \"world\" with occurrence count 4");
+    }
+
+    @Test
+    public void findWords_shouldPreserveApostrophes() {
+        // GIVEN notes where words contain apostrophes:
+        Note note1 = new Note();
+        note1.setText("isn't that amazing isn't that amazing");
+        Note note2 = new Note();
+        note2.setText("isn't that amazing");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN apostrophes should be preserved so "isn't" is treated as one word:
+        List<Word> words = result.getWords();
+        assertTrue(words.stream().anyMatch(w -> w.word().equals("isn't")),
+                   "Expected \"isn't\" to be present as a single word");
+        assertFalse(words.stream().anyMatch(w -> w.word().equals("isn") || w.word().equals("t")),
+                    "Apostrophe should not cause \"isn't\" to be split into \"isn\" and \"t\"");
+    }
+
+    @Test
+    public void findWords_shouldReturnWordsInDecreasingOrderOfOccurrence() {
+        // GIVEN notes where "hello" appears more often than "world" and "world" more than "amazing":
+        Note note1 = new Note();
+        note1.setText("hello hello hello world world amazing");
+        Note note2 = new Note();
+        note2.setText("hello hello world amazing");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN words should be returned in decreasing order of occurrence count:
+        List<Word> words = result.getWords();
+        assertFalse(words.isEmpty());
+        for (int i = 0; i < words.size() - 1; i++) {
+            assertTrue(words.get(i).occurrenceCount() >= words.get(i + 1).occurrenceCount(),
+                       "Words should be in decreasing order of occurrence count");
+        }
+        assertEquals("hello", words.get(0).word());
+    }
+
+    @Test
+    public void findWords_shouldLimitResultsToN() {
+        // GIVEN a note with several recurring long words:
+        Note note1 = new Note();
+        note1.setText("alpha bravo charlie delta echo foxtrot");
+        Note note2 = new Note();
+        note2.setText("alpha bravo charlie delta echo foxtrot");
+
+        // WHEN we call findWords with N = 3:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 3);
+
+        // THEN at most 3 words should be returned:
+        assertTrue(result.getWords().size() <= 3,
+                   "Result should contain at most N=3 words");
+    }
+
+    @Test
+    public void findWords_withNGreaterThanAvailableWords_shouldReturnAllAvailableWords() {
+        // GIVEN a note where only 2 long words recur:
+        Note note1 = new Note();
+        note1.setText("hello world");
+        Note note2 = new Note();
+        note2.setText("hello world");
+
+        // WHEN we call findWords requesting more than the number of available recurring words:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 100);
+
+        // THEN we should get back only the 2 available recurring words (not an error):
+        assertEquals(2, result.getWords().size());
+    }
+
+    @Test
+    public void findWords_shouldCountAcrossMultipleNotes() {
+        // GIVEN the same word spread across multiple notes:
+        Note note1 = new Note();
+        note1.setText("hello there");
+        Note note2 = new Note();
+        note2.setText("hello again");
+        Note note3 = new Note();
+        note3.setText("hello everyone");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2, note3), 10);
+
+        // THEN "hello" should be counted 3 times (once per note):
+        List<Word> words = result.getWords();
+        assertTrue(words.stream().anyMatch(w -> w.word().equals("hello") && w.occurrenceCount() == 3),
+                   "Expected \"hello\" with occurrence count 3 across all notes");
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // findWords - unique word count tests
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void findWords_withNullNotes_shouldReturnNoDataForUniqueWordCount() {
+        // GIVEN a null note list:
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(null, 10);
+
+        // THEN uniqueWordCount should be NO_DATA because no scanning was performed:
+        assertEquals(WordList.NO_DATA, result.getUniqueWordCount());
+    }
+
+    @Test
+    public void findWords_withEmptyNotes_shouldReturnNoDataForUniqueWordCount() {
+        // GIVEN an empty note list:
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(), 10);
+
+        // THEN uniqueWordCount should be NO_DATA because no scanning was performed:
+        assertEquals(WordList.NO_DATA, result.getUniqueWordCount());
+    }
+
+    @Test
+    public void findWords_withZeroN_shouldReturnNoDataForUniqueWordCount() {
+        // GIVEN a note with text:
+        Note note = new Note();
+        note.setText("hello world hello world");
+
+        // WHEN we call findWords with N = 0:
+        WordList result = StatisticsUtil.findWords(List.of(note), 0);
+
+        // THEN uniqueWordCount should be NO_DATA because we bailed out early:
+        assertEquals(WordList.NO_DATA, result.getUniqueWordCount());
+    }
+
+    @Test
+    public void findWords_shouldTrackUniqueWordCount() {
+        // GIVEN a note with three distinct words:
+        Note note = new Note();
+        note.setText("alpha bravo charlie");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note), 10);
+
+        // THEN the unique word count should reflect all three distinct words seen:
+        assertEquals(3, result.getUniqueWordCount());
+    }
+
+    @Test
+    public void findWords_shouldIncludeShortWordsInUniqueWordCount() {
+        // GIVEN a note where some words are shorter than MIN_WORD_LENGTH ("the", "cat"):
+        Note note = new Note();
+        note.setText("the cat sits");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note), 10);
+
+        // THEN short words should NOT appear in the returned word list (they are filtered),
+        // but they SHOULD still be counted in the unique word count:
+        assertTrue(result.getWords().stream().noneMatch(w -> w.word().equals("the") || w.word().equals("cat")),
+                   "Short words should be excluded from the returned word list");
+        assertEquals(3, result.getUniqueWordCount(),
+                     "Short words should still be counted in the unique word count");
+    }
+
+    @Test
+    public void findWords_shouldIncludeSingleOccurrenceWordsInUniqueWordCount() {
+        // GIVEN two notes where all long words appear only once (and are therefore pruned from results):
+        Note note1 = new Note();
+        note1.setText("alpha bravo charlie");
+        Note note2 = new Note();
+        note2.setText("delta echo foxtrot");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN no words should be returned (all single-occurrence), but the unique word
+        // count should still reflect all 6 distinct words that were scanned:
+        assertTrue(result.getWords().isEmpty(),
+                   "All single-occurrence words should be pruned from results");
+        assertEquals(6, result.getUniqueWordCount(),
+                     "All scanned words should be counted in unique word count even if pruned from results");
+    }
+
+    @Test
+    public void findWords_shouldDeduplicateUniqueWordsAcrossNotes() {
+        // GIVEN the same word appearing in two separate notes:
+        Note note1 = new Note();
+        note1.setText("hello world");
+        Note note2 = new Note();
+        note2.setText("hello world");
+
+        // WHEN we call findWords:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN the unique word count should be 2 (not 4), since "hello" and "world"
+        // are the same two unique words regardless of how many notes contain them:
+        assertEquals(2, result.getUniqueWordCount(),
+                     "Unique word count should deduplicate the same word seen in multiple notes");
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // findWords(List<Note>, Set<String>, int) - specific-words overload tests
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void findWords_withSpecificWords_shouldCountOnlyWordsInTheSet() {
+        // GIVEN notes that contain several recurring words:
+        Note note1 = new Note();
+        note1.setText("hello world today hello world today");
+        Note note2 = new Note();
+        note2.setText("hello world today");
+
+        // AND we only want to count "hello":
+        Set<String> specificWords = Set.of("hello");
+
+        // WHEN we call the specific-words overload:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), specificWords, 10);
+
+        // THEN only "hello" should be present in the result:
+        List<Word> words = result.getWords();
+        assertEquals(1, words.size(), "Only the specified word should be returned");
+        assertEquals("hello", words.get(0).word());
+        assertEquals(3, words.get(0).occurrenceCount());
+    }
+
+    @Test
+    public void findWords_withSpecificWords_shouldIgnoreMinWordLength() {
+        // GIVEN notes with a short recurring word that would normally be filtered by MIN_WORD_LENGTH:
+        Note note1 = new Note();
+        note1.setText("the cat sat");
+        Note note2 = new Note();
+        note2.setText("the cat sat");
+
+        // AND we explicitly ask for "the" (which is shorter than MIN_WORD_LENGTH):
+        Set<String> specificWords = Set.of("the");
+
+        // WHEN we call the specific-words overload:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), specificWords, 10);
+
+        // THEN "the" should be counted even though it is shorter than MIN_WORD_LENGTH:
+        List<Word> words = result.getWords();
+        assertTrue(words.stream().anyMatch(w -> w.word().equals("the") && w.occurrenceCount() == 2),
+                   "Words shorter than MIN_WORD_LENGTH should be counted when listed in specificWords");
+    }
+
+    @Test
+    public void findWords_withSpecificWords_shouldIgnoreWordsNotInTheSet() {
+        // GIVEN notes containing both "hello" and "world", recurring multiple times:
+        Note note1 = new Note();
+        note1.setText("hello world hello world");
+        Note note2 = new Note();
+        note2.setText("hello world");
+
+        // AND we only ask for "hello":
+        Set<String> specificWords = Set.of("hello");
+
+        // WHEN we call the specific-words overload:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), specificWords, 10);
+
+        // THEN "world" should NOT appear in the results, even though it recurs:
+        List<Word> words = result.getWords();
+        assertTrue(words.stream().noneMatch(w -> w.word().equals("world")),
+                   "Words not in the specificWords set should be excluded from results");
+    }
+
+    @Test
+    public void findWords_withNullSpecificWords_shouldBehaveLikeGeneralOverload() {
+        // GIVEN a note with recurring long words:
+        Note note1 = new Note();
+        note1.setText("hello world hello world");
+        Note note2 = new Note();
+        note2.setText("hello world");
+
+        // WHEN we call the specific-words overload with null:
+        WordList withNull = StatisticsUtil.findWords(List.of(note1, note2), null, 10);
+
+        // AND we call the general overload for comparison:
+        WordList withoutSet = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN both should return the same words and counts:
+        assertEquals(withoutSet.getWords().size(), withNull.getWords().size());
+        for (int i = 0; i < withoutSet.getWords().size(); i++) {
+            assertEquals(withoutSet.getWords().get(i).word(), withNull.getWords().get(i).word());
+            assertEquals(withoutSet.getWords().get(i).occurrenceCount(), withNull.getWords().get(i).occurrenceCount());
+        }
+    }
+
+    @Test
+    public void findWords_withEmptySpecificWords_shouldBehaveLikeGeneralOverload() {
+        // GIVEN a note with recurring long words:
+        Note note1 = new Note();
+        note1.setText("hello world hello world");
+        Note note2 = new Note();
+        note2.setText("hello world");
+
+        // WHEN we call the specific-words overload with an empty set:
+        WordList withEmpty = StatisticsUtil.findWords(List.of(note1, note2), Set.of(), 10);
+
+        // AND we call the general overload for comparison:
+        WordList withoutSet = StatisticsUtil.findWords(List.of(note1, note2), 10);
+
+        // THEN both should return the same words and counts:
+        assertEquals(withoutSet.getWords().size(), withEmpty.getWords().size());
+        for (int i = 0; i < withoutSet.getWords().size(); i++) {
+            assertEquals(withoutSet.getWords().get(i).word(), withEmpty.getWords().get(i).word());
+            assertEquals(withoutSet.getWords().get(i).occurrenceCount(), withEmpty.getWords().get(i).occurrenceCount());
+        }
+    }
+
+    @Test
+    public void findWords_withSpecificWords_shouldStillTrackUniqueWordCount() {
+        // GIVEN notes with several distinct words:
+        Note note1 = new Note();
+        note1.setText("hello world today");
+        Note note2 = new Note();
+        note2.setText("hello world tomorrow");
+
+        // AND we only ask for "hello":
+        Set<String> specificWords = Set.of("hello");
+
+        // WHEN we call the specific-words overload:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), specificWords, 10);
+
+        // THEN the unique word count should reflect ALL distinct words scanned (4),
+        // not just the words in the specific set (1):
+        assertEquals(4, result.getUniqueWordCount(),
+                     "Unique word count should track all scanned words, even when specificWords is used");
+    }
+
+    @Test
+    public void findWords_withSpecificWordNotPresentInNotes_shouldReturnEmptyWordList() {
+        // GIVEN notes that do not contain the requested word at all:
+        Note note1 = new Note();
+        note1.setText("hello world hello world");
+        Note note2 = new Note();
+        note2.setText("hello world");
+
+        // AND we ask for a word that does not appear in any note:
+        Set<String> specificWords = Set.of("elephant");
+
+        // WHEN we call the specific-words overload:
+        WordList result = StatisticsUtil.findWords(List.of(note1, note2), specificWords, 10);
+
+        // THEN the returned word list should be empty:
+        assertTrue(result.getWords().isEmpty(),
+                   "Word list should be empty when the specified word does not appear in any note");
     }
 }


### PR DESCRIPTION
This PR addresses issue #18 by adding word-based statistics, very similar to what was done with phrases. A list of the top 25 most-frequently-occurring words is gathered when statistics are loaded. Short words (currently defined as having fewer than 5 characters) are excluded from the search, because they are not interesting. The top 25 results are displayed on a new "Most common words" tab in the `StatisticsDialog`. The user is also offered a simple search form, where on-the-fly searching for specific words is possible. The minimum word length is ignored when searching for specific words.

Additionally, a count of globally unique words (including short words) is calculated during statistics loading. This is also displayed on the Words tab. Code was added to allow this feature to be disabled easily later, but currently it is always enabled.

Closes #18 